### PR TITLE
fix version of spring dependencies

### DIFF
--- a/the-mathmos-parent/pom.xml
+++ b/the-mathmos-parent/pom.xml
@@ -36,9 +36,9 @@
 		<powermock-version>1.6.5</powermock-version>
 		<rest-assured-version>3.0.1</rest-assured-version>
 		<slf4j-log4j12-version>1.7.21</slf4j-log4j12-version>
-		<spring-framework-version>5.0.0.RC3</spring-framework-version>
+		<spring-framework-version>5.0.0.RELEASE</spring-framework-version>
 		<spring-security-version>5.0.0.RC3</spring-security-version>
-		<spring-data-elasticsearch-version>3.0.0.RC2</spring-data-elasticsearch-version>
+		<spring-data-elasticsearch-version>3.0.0.RELEASE</spring-data-elasticsearch-version>
 	</properties>
 
 	<build>


### PR DESCRIPTION
The jar files for the spring-framework 5.0.0.RC3 and spring-data-elasticsearch 3.0.0.RC2  do not exist (anymore) in the repository.